### PR TITLE
Fix error message and remove network name from header button

### DIFF
--- a/app/sections/Header/Header.tsx
+++ b/app/sections/Header/Header.tsx
@@ -46,7 +46,7 @@ const Header = () => {
         <Button onClick={handleConnectWallet}>
           {walletAddress ? (
             <>
-              {`${ensName ?? truncateAddress(walletAddress)} MAINNET`}
+              {ensName ?? truncateAddress(walletAddress)}
               <Image
                 src={connectWalletArrow}
                 alt="Connect Wallet Arrow"
@@ -92,9 +92,11 @@ const Button = styled.button`
   cursor: pointer;
   background-color: #cf1c8e;
   text-transform: uppercase;
+  padding-left: 4px;
+  padding-right: 4px;
 
   div {
-    margin-left: 6px;
+    margin-left: 10px;
   }
 `;
 

--- a/app/sections/Swapper/Swapper.tsx
+++ b/app/sections/Swapper/Swapper.tsx
@@ -98,6 +98,11 @@ const Swapper = () => {
       try {
         setError(null);
         if (Number(depositAmount) === 0) throw new Error("Incorrect amount");
+        if (Number(depositAmount) > (ethBalance?.balance ?? 0)) {
+          throw new Error(
+            "Amount of ETH selected to Teleport is more than what is available in your wallet"
+          );
+        }
         if (burnerWalletBalance === 0)
           throw new Error("Burner wallet has a low balance");
         if (Number(depositAmount) > contractInfo.maxDepositAmount)


### PR DESCRIPTION
This PR adds a more readable error message for when wallet resources are insufficient to carry out the teleport operation. It also removes the network name (MAINNET) from the "Connect Wallet" button in the header.